### PR TITLE
adds react 17 support and refactors form ids so they support ssr

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "peerDependencies": {
     "classnames": "^2.2.6",
     "prop-types": "^15.6.2",
-    "react": "^16.8.3",
-    "react-dom": "^16.8.3"
+    "react": "^16.8.3 || ^17.0.0",
+    "react-dom": "^16.8.3 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/src/components/checkboxfield/CheckboxField.js
+++ b/src/components/checkboxfield/CheckboxField.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 
 import Field from '../field/Field';
 import Checkbox from '../checkbox/Checkbox';
+import { generateUniqueId } from '../../utils/generateUniqueId';
 
 import './CheckboxField.css';
 
 class CheckboxField extends Component {
   constructor(props) {
     super(props);
-    window.stxFieldCount = window.stxFieldCount ? window.stxFieldCount + 1 : 1;
-    this.forId = `stxField${window.stxFieldCount}`;
+    this.forId = `stxField${generateUniqueId()}`;
   }
 
   render() {

--- a/src/components/inputfield/InputField.js
+++ b/src/components/inputfield/InputField.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types';
 
 import Field from '../field/Field';
 import Input from '../input/Input';
+import { generateUniqueId } from '../../utils/generateUniqueId';
 
 import './InputField.css';
 
 class InputField extends Component {
   constructor(props) {
     super(props);
-    window.stxFieldCount = window.stxFieldCount ? window.stxFieldCount + 1 : 1;
-    this.forId = `stxField${window.stxFieldCount}`;
+    this.forId = `stxField${generateUniqueId()}`;
   }
 
   render() {

--- a/src/components/message/__snapshots__/Message.test.js.snap
+++ b/src/components/message/__snapshots__/Message.test.js.snap
@@ -4,6 +4,7 @@ exports[`Message Message renders additional data props 1`] = `
 <Message
   className="the-class"
   data-additional-prop="additional-prop"
+  dismissText="Dismiss"
   dismissType="string"
   id="the-id"
 >
@@ -21,6 +22,7 @@ exports[`Message Message renders additional data props 1`] = `
 exports[`Message Message renders with basic props 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="string"
   id="the-id"
 >
@@ -37,6 +39,7 @@ exports[`Message Message renders with basic props 1`] = `
 exports[`Message Message renders with default dismiss button 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="string"
   dismissible={true}
   id="the-id"
@@ -48,7 +51,7 @@ exports[`Message Message renders with default dismiss button 1`] = `
     role="status"
   >
     <Button
-      aria-label="close"
+      aria-label="Dismiss"
       block={false}
       className="stx-message__dismiss-button"
       disabled={false}
@@ -65,7 +68,7 @@ exports[`Message Message renders with default dismiss button 1`] = `
       <button
         aria-busy={false}
         aria-disabled={false}
-        aria-label="close"
+        aria-label="Dismiss"
         className="stx-button stx-button--secondary stx-message__dismiss-button"
         disabled={false}
         href={null}
@@ -95,6 +98,7 @@ exports[`Message Message renders with default dismiss button 1`] = `
 exports[`Message Message renders with dismiss icon button 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="icon"
   dismissible={true}
   id="the-id"
@@ -106,7 +110,7 @@ exports[`Message Message renders with dismiss icon button 1`] = `
     role="status"
   >
     <Button
-      aria-label="close"
+      aria-label="Dismiss"
       block={false}
       className="stx-message__dismiss-button"
       disabled={false}
@@ -123,7 +127,7 @@ exports[`Message Message renders with dismiss icon button 1`] = `
       <button
         aria-busy={false}
         aria-disabled={false}
-        aria-label="close"
+        aria-label="Dismiss"
         className="stx-button stx-button--secondary stx-message__dismiss-button"
         disabled={false}
         href={null}
@@ -166,6 +170,7 @@ exports[`Message Message renders with dismiss icon button 1`] = `
 exports[`Message Message renders with title 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="string"
   id="the-id"
   title="title"
@@ -188,6 +193,7 @@ exports[`Message Message renders with title 1`] = `
 exports[`Message Message renders with type = alert 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="string"
   id="the-id"
   type="alert"
@@ -205,6 +211,7 @@ exports[`Message Message renders with type = alert 1`] = `
 exports[`Message Message renders with type = info 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="string"
   id="the-id"
   type="info"
@@ -222,6 +229,7 @@ exports[`Message Message renders with type = info 1`] = `
 exports[`Message Message renders with type = success 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="string"
   id="the-id"
   type="success"
@@ -239,6 +247,7 @@ exports[`Message Message renders with type = success 1`] = `
 exports[`Message Message renders with type = warning 1`] = `
 <Message
   className="the-class"
+  dismissText="Dismiss"
   dismissType="string"
   id="the-id"
   type="warning"

--- a/src/components/pill/Pill.js
+++ b/src/components/pill/Pill.js
@@ -22,13 +22,13 @@ function Pill(props) {
   ]);
 
   const timesIcon = <span className='stx-pill__icon'>
-  <svg
-    className='stx-pill-icon__icon'
-    viewBox='0 0 24 24'
-  >
-    <path className='stx-pill-icon__path' fill='#6B6B6B' d={times} />
-  </svg>
-</span>;
+    <svg
+      className='stx-pill-icon__icon'
+      viewBox='0 0 24 24'
+    >
+      <path className='stx-pill-icon__path' fill='#6B6B6B' d={times} />
+    </svg>
+  </span>;
 
   return (
     <span
@@ -36,7 +36,7 @@ function Pill(props) {
       className={classNames}
       onClick={onClick}
     >
-      <span className="stx-pill__label">
+      <span className='stx-pill__label'>
         { label }
       </span>
       { dismissible && <button

--- a/src/components/radiofield/RadioField.js
+++ b/src/components/radiofield/RadioField.js
@@ -4,19 +4,18 @@ import PropTypes from 'prop-types';
 
 import Field from '../field/Field';
 import Radio from '../radio/Radio';
+import { generateUniqueId } from '../../utils/generateUniqueId';
 
 import './RadioField.css';
 
 class RadioField extends Component {
   constructor(props) {
     super(props);
-    window.stxFieldCount = window.stxFieldCount ? window.stxFieldCount + 1 : 1;
-    this.forId = `stxField${window.stxFieldCount}`;
+    this.forId = `stxField${generateUniqueId()}`;
   }
 
   render() {
     const { className, disabled, helpText, id, label, messageType, messageText, value, ...otherProps } = this.props;
-
     const classNames = cn([
       'stx-field--with-radio-field',
       className,

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -29,7 +29,6 @@ class Select extends Component {
       messageType,
       placeholder,
       hasValue,
-      hasFocus,
       loading,
       readOnly,
       value,

--- a/src/components/selectfield/SelectField.js
+++ b/src/components/selectfield/SelectField.js
@@ -4,15 +4,14 @@ import PropTypes from 'prop-types';
 
 import Field from '../field/Field';
 import Select from '../select/Select';
+import { generateUniqueId } from '../../utils/generateUniqueId';
 
 import './SelectField.css';
 
 class SelectField extends Component {
   constructor(props) {
     super(props);
-
-    window.stxFieldCount = window.stxFieldCount ? window.stxFieldCount + 1 : 1;
-    this.forId = `stxField${window.stxFieldCount}`;
+    this.forId = `stxField${generateUniqueId()}`;
   }
 
   render() {

--- a/src/utils/generateUniqueId.js
+++ b/src/utils/generateUniqueId.js
@@ -1,0 +1,12 @@
+let stxFieldCount = 0;
+
+export function generateUniqueId() {
+  if (typeof window === 'undefined') {
+    stxFieldCount += 1;
+  } else {
+    window.stxFieldCount = window.stxFieldCount ? window.stxFieldCount + 1 : 1;
+    stxFieldCount = window.stxFieldCount;
+  }
+
+  return stxFieldCount;
+}


### PR DESCRIPTION
**Changelog:**
- Adds support for React 17
- Updated failing snapshot test
- Added utility function to generate a unique id. When in browser it will use a global variable in window to keep track of ids so if there are multiple packages bundled that utilize stacks-ui they will play nicely together. But if window doesn't exist, then it uses a variable scoped to the bundle instead to keep track of ids which would only happen when the application is being rendered server side.