### PR TITLE
Add screen reader error announcement to field components

### DIFF
--- a/src/components/checkboxfield/CheckboxField.js
+++ b/src/components/checkboxfield/CheckboxField.js
@@ -12,14 +12,17 @@ class CheckboxField extends Component {
   constructor(props) {
     super(props);
     this.forId = `stxField${generateUniqueId()}`;
+    this.messageId = `stxFieldMessage${generateUniqueId()}`;
   }
 
   render() {
-    const { id, className, helpText, messageType, messageText, label, ...remainingProps } = this.props;
+    const { id, className, helpText, messageType, messageText, messageId, label, ...remainingProps } = this.props;
     const classNames = cn([
       'stx-checkbox-field__field',
       className,
     ]);
+
+    const hasValidationError = messageType === 'alert' || messageType === 'error';
 
     return (
       <Field
@@ -27,11 +30,14 @@ class CheckboxField extends Component {
         helpText={helpText}
         messageType={messageType}
         messageText={messageText}
+        messageId={this.messageId}
       >
         <div className='stx-checkbox-field__div'>
           <Checkbox
             id={id || this.forId}
             className='stx-checkbox-field__checkbox'
+            aria-invalid={hasValidationError ? 'true' : undefined}
+            aria-describedby={messageId || this.messageId}
             {...remainingProps}
           />
 
@@ -58,6 +64,8 @@ CheckboxField.propTypes = {
   messageText: PropTypes.string,
   /** The type of message to display */
   messageType: PropTypes.oneOf(['alert', 'warning', 'success', '']),
+  /** The ID of the associated message element (automatically generated if not provided) */
+  messageId: PropTypes.oneOf([PropTypes.string, PropTypes.undefined]),
   /** Whether or not the checkbox is disabled */
   disabled: PropTypes.bool,
 };

--- a/src/components/checkboxfield/__snapshots__/CheckboxField.test.js.snap
+++ b/src/components/checkboxfield/__snapshots__/CheckboxField.test.js.snap
@@ -3,18 +3,20 @@
 exports[`CheckboxField CheckboxField render additional props 1`] = `
 <Field
   className="stx-checkbox-field__field"
+  messageId="stxFieldMessage18"
 >
   <div
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage18"
       className="stx-checkbox-field__checkbox"
       data-additional-prop="additional-prop"
-      id="stxField9"
+      id="stxField17"
     />
     <label
       className="stx-checkbox-field__label"
-      htmlFor="stxField9"
+      htmlFor="stxField17"
     />
   </div>
 </Field>
@@ -23,18 +25,20 @@ exports[`CheckboxField CheckboxField render additional props 1`] = `
 exports[`CheckboxField CheckboxField render disabled when disabled is true 1`] = `
 <Field
   className="stx-checkbox-field__field"
+  messageId="stxFieldMessage16"
 >
   <div
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage16"
       className="stx-checkbox-field__checkbox"
       disabled={true}
-      id="stxField8"
+      id="stxField15"
     />
     <label
       className="stx-checkbox-field__label"
-      htmlFor="stxField8"
+      htmlFor="stxField15"
     />
   </div>
 </Field>
@@ -43,33 +47,14 @@ exports[`CheckboxField CheckboxField render disabled when disabled is true 1`] =
 exports[`CheckboxField CheckboxField renders checked 1`] = `
 <Field
   className="stx-checkbox-field__field"
+  messageId="stxFieldMessage6"
 >
   <div
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage6"
       checked={true}
-      className="stx-checkbox-field__checkbox"
-      id="stxField3"
-    />
-    <label
-      className="stx-checkbox-field__label"
-      htmlFor="stxField3"
-    />
-  </div>
-</Field>
-`;
-
-exports[`CheckboxField CheckboxField renders with a success messageText 1`] = `
-<Field
-  className="stx-checkbox-field__field"
-  messageText="message-text"
-  messageType="success"
->
-  <div
-    className="stx-checkbox-field__div"
-  >
-    <Checkbox
       className="stx-checkbox-field__checkbox"
       id="stxField5"
     />
@@ -81,9 +66,33 @@ exports[`CheckboxField CheckboxField renders with a success messageText 1`] = `
 </Field>
 `;
 
+exports[`CheckboxField CheckboxField renders with a success messageText 1`] = `
+<Field
+  className="stx-checkbox-field__field"
+  messageId="stxFieldMessage10"
+  messageText="message-text"
+  messageType="success"
+>
+  <div
+    className="stx-checkbox-field__div"
+  >
+    <Checkbox
+      aria-describedby="stxFieldMessage10"
+      className="stx-checkbox-field__checkbox"
+      id="stxField9"
+    />
+    <label
+      className="stx-checkbox-field__label"
+      htmlFor="stxField9"
+    />
+  </div>
+</Field>
+`;
+
 exports[`CheckboxField CheckboxField renders with a warning messageText 1`] = `
 <Field
   className="stx-checkbox-field__field"
+  messageId="stxFieldMessage12"
   messageText="message-text"
   messageType="warning"
 >
@@ -91,12 +100,13 @@ exports[`CheckboxField CheckboxField renders with a warning messageText 1`] = `
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage12"
       className="stx-checkbox-field__checkbox"
-      id="stxField6"
+      id="stxField11"
     />
     <label
       className="stx-checkbox-field__label"
-      htmlFor="stxField6"
+      htmlFor="stxField11"
     />
   </div>
 </Field>
@@ -105,6 +115,7 @@ exports[`CheckboxField CheckboxField renders with a warning messageText 1`] = `
 exports[`CheckboxField CheckboxField renders with an alert messageText 1`] = `
 <Field
   className="stx-checkbox-field__field"
+  messageId="stxFieldMessage14"
   messageText="message-text"
   messageType="alert"
 >
@@ -112,12 +123,14 @@ exports[`CheckboxField CheckboxField renders with an alert messageText 1`] = `
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage14"
+      aria-invalid="true"
       className="stx-checkbox-field__checkbox"
-      id="stxField7"
+      id="stxField13"
     />
     <label
       className="stx-checkbox-field__label"
-      htmlFor="stxField7"
+      htmlFor="stxField13"
     />
   </div>
 </Field>
@@ -126,11 +139,13 @@ exports[`CheckboxField CheckboxField renders with an alert messageText 1`] = `
 exports[`CheckboxField CheckboxField renders with basic props 1`] = `
 <Field
   className="stx-checkbox-field__field html-class"
+  messageId="stxFieldMessage2"
 >
   <div
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage2"
       className="stx-checkbox-field__checkbox"
       id="test-id"
       name="name"
@@ -152,17 +167,19 @@ exports[`CheckboxField CheckboxField renders with helpText 1`] = `
 <Field
   className="stx-checkbox-field__field"
   helpText="help-text"
+  messageId="stxFieldMessage8"
 >
   <div
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage8"
       className="stx-checkbox-field__checkbox"
-      id="stxField4"
+      id="stxField7"
     />
     <label
       className="stx-checkbox-field__label"
-      htmlFor="stxField4"
+      htmlFor="stxField7"
     />
   </div>
 </Field>
@@ -171,17 +188,19 @@ exports[`CheckboxField CheckboxField renders with helpText 1`] = `
 exports[`CheckboxField CheckboxField renders without any props 1`] = `
 <Field
   className="stx-checkbox-field__field"
+  messageId="stxFieldMessage4"
 >
   <div
     className="stx-checkbox-field__div"
   >
     <Checkbox
+      aria-describedby="stxFieldMessage4"
       className="stx-checkbox-field__checkbox"
-      id="stxField2"
+      id="stxField3"
     />
     <label
       className="stx-checkbox-field__label"
-      htmlFor="stxField2"
+      htmlFor="stxField3"
     />
   </div>
 </Field>

--- a/src/components/field/Field.js
+++ b/src/components/field/Field.js
@@ -6,7 +6,7 @@ import './Field.css';
 
 function Field(props) {
   const {
-    children, className, disabled, helpText, htmlFor, id, label, messageText, messageType, ariaLive, ...otherProps
+    children, className, disabled, helpText, htmlFor, id, messageId, label, messageText, messageType, ariaLive, ...otherProps
   } = props;
 
   const classNames = cn([
@@ -19,7 +19,7 @@ function Field(props) {
   ]);
 
   const renderMessageText = () => {
-    return messageText && <div className='stx-field__message' aria-live={ariaLive}>{ messageText }</div>;
+    return messageText && <div className='stx-field__message' aria-live={ariaLive} id={messageId}>{ messageText }</div>;
   };
 
   const renderHelpText = () => {
@@ -72,6 +72,9 @@ Field.propTypes = {
 
   /** The text to display for the message */
   messageText: PropTypes.string,
+
+  /** A unique ID for the message element */
+  messageId: PropTypes.string,
 
   /** Child elements */
   children: PropTypes.node,

--- a/src/components/inputfield/InputField.js
+++ b/src/components/inputfield/InputField.js
@@ -12,14 +12,17 @@ class InputField extends Component {
   constructor(props) {
     super(props);
     this.forId = `stxField${generateUniqueId()}`;
+    this.messageId = `stxFieldMessage${generateUniqueId()}`;
   }
 
   render() {
-    const { className, disabled, helpText, id, label, messageText, messageType, readOnly, ariaLive, ...otherProps } = this.props;
+    const { className, disabled, helpText, id, label, messageText, messageType, messageId, readOnly, ariaLive, ...otherProps } = this.props;
     const classNames = cn([
       'stx-field--with-input',
       className,
     ]);
+
+    const hasValidationError = messageType === 'alert' || messageType === 'error';
 
     return (
       <Field
@@ -29,6 +32,7 @@ class InputField extends Component {
         className={classNames}
         messageType={messageType}
         messageText={messageText}
+        messageId={messageId || this.messageId}
         disabled={disabled}
         readOnly={readOnly}
         ariaLive={ariaLive}
@@ -39,6 +43,8 @@ class InputField extends Component {
           messageType={messageType}
           disabled={disabled}
           readOnly={readOnly}
+          aria-invalid={hasValidationError ? 'true' : undefined}
+          aria-describedby={messageId || this.messageId}
         />
       </Field>
     );
@@ -59,6 +65,8 @@ InputField.propTypes = {
   messageType: PropTypes.oneOf(['success', 'warning', 'alert', '']),
   /** The text that should appear as a message */
   messageText: PropTypes.string,
+  /** The ID of the associated message element */
+  messageId: PropTypes.oneOf([PropTypes.string, PropTypes.undefined]),
   /** The aria-live attribute value that will be set on the message if one is given */
   ariaLive: PropTypes.oneOf(['assertive', 'polite']),
   /** Whether or not the field is disabled */

--- a/src/components/inputfield/__snapshots__/InputField.test.js.snap
+++ b/src/components/inputfield/__snapshots__/InputField.test.js.snap
@@ -4,11 +4,13 @@ exports[`InputField InputField render disabled when disabled is true 1`] = `
 <Field
   className="stx-field--with-input"
   disabled={true}
-  htmlFor="stxField25"
+  htmlFor="stxField49"
+  messageId="stxFieldMessage50"
 >
   <Input
+    aria-describedby="stxFieldMessage50"
     disabled={true}
-    id="stxField25"
+    id="stxField49"
     selectOnFocus={false}
     type="text"
   />
@@ -18,11 +20,13 @@ exports[`InputField InputField render disabled when disabled is true 1`] = `
 exports[`InputField InputField render readOnly when readOnly is true 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField26"
+  htmlFor="stxField51"
+  messageId="stxFieldMessage52"
   readOnly={true}
 >
   <Input
-    id="stxField26"
+    aria-describedby="stxFieldMessage52"
+    id="stxField51"
     readOnly={true}
     selectOnFocus={false}
     type="text"
@@ -33,10 +37,12 @@ exports[`InputField InputField render readOnly when readOnly is true 1`] = `
 exports[`InputField InputField render with a loading spinner when loading is true 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField27"
+  htmlFor="stxField53"
+  messageId="stxFieldMessage54"
 >
   <Input
-    id="stxField27"
+    aria-describedby="stxFieldMessage54"
+    id="stxField53"
     loading={true}
     selectOnFocus={false}
     type="text"
@@ -47,11 +53,13 @@ exports[`InputField InputField render with a loading spinner when loading is tru
 exports[`InputField InputField renders with a autoComplete value 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField24"
+  htmlFor="stxField47"
+  messageId="stxFieldMessage48"
 >
   <Input
+    aria-describedby="stxFieldMessage48"
     autoComplete="off"
-    id="stxField24"
+    id="stxField47"
     selectOnFocus={false}
     type="text"
   />
@@ -61,11 +69,14 @@ exports[`InputField InputField renders with a autoComplete value 1`] = `
 exports[`InputField InputField renders with a message type of alert 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField17"
+  htmlFor="stxField33"
+  messageId="stxFieldMessage34"
   messageType="alert"
 >
   <Input
-    id="stxField17"
+    aria-describedby="stxFieldMessage34"
+    aria-invalid="true"
+    id="stxField33"
     messageType="alert"
     selectOnFocus={false}
     type="text"
@@ -76,11 +87,13 @@ exports[`InputField InputField renders with a message type of alert 1`] = `
 exports[`InputField InputField renders with a message type of success 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField19"
+  htmlFor="stxField37"
+  messageId="stxFieldMessage38"
   messageType="success"
 >
   <Input
-    id="stxField19"
+    aria-describedby="stxFieldMessage38"
+    id="stxField37"
     messageType="success"
     selectOnFocus={false}
     type="text"
@@ -91,11 +104,13 @@ exports[`InputField InputField renders with a message type of success 1`] = `
 exports[`InputField InputField renders with a message type of warning 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField18"
+  htmlFor="stxField35"
+  messageId="stxFieldMessage36"
   messageType="warning"
 >
   <Input
-    id="stxField18"
+    aria-describedby="stxFieldMessage36"
+    id="stxField35"
     messageType="warning"
     selectOnFocus={false}
     type="text"
@@ -106,10 +121,12 @@ exports[`InputField InputField renders with a message type of warning 1`] = `
 exports[`InputField InputField renders with a min and max length 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField21"
+  htmlFor="stxField41"
+  messageId="stxFieldMessage42"
 >
   <Input
-    id="stxField21"
+    aria-describedby="stxFieldMessage42"
+    id="stxField41"
     maxLength={5}
     minLength={1}
     selectOnFocus={false}
@@ -121,10 +138,12 @@ exports[`InputField InputField renders with a min and max length 1`] = `
 exports[`InputField InputField renders with a min and max value 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField20"
+  htmlFor="stxField39"
+  messageId="stxFieldMessage40"
 >
   <Input
-    id="stxField20"
+    aria-describedby="stxFieldMessage40"
+    id="stxField39"
     max={5}
     min={1}
     selectOnFocus={false}
@@ -136,10 +155,12 @@ exports[`InputField InputField renders with a min and max value 1`] = `
 exports[`InputField InputField renders with a prefix 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField3"
+  htmlFor="stxField5"
+  messageId="stxFieldMessage6"
 >
   <Input
-    id="stxField3"
+    aria-describedby="stxFieldMessage6"
+    id="stxField5"
     prefix="-"
     selectOnFocus={false}
     type="text"
@@ -150,10 +171,12 @@ exports[`InputField InputField renders with a prefix 1`] = `
 exports[`InputField InputField renders with a step value 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField22"
+  htmlFor="stxField43"
+  messageId="stxFieldMessage44"
 >
   <Input
-    id="stxField22"
+    aria-describedby="stxFieldMessage44"
+    id="stxField43"
     selectOnFocus={false}
     step={5}
     type="text"
@@ -164,10 +187,12 @@ exports[`InputField InputField renders with a step value 1`] = `
 exports[`InputField InputField renders with a suffix 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField4"
+  htmlFor="stxField7"
+  messageId="stxFieldMessage8"
 >
   <Input
-    id="stxField4"
+    aria-describedby="stxFieldMessage8"
+    id="stxField7"
     selectOnFocus={false}
     suffix="px"
     type="text"
@@ -178,10 +203,12 @@ exports[`InputField InputField renders with a suffix 1`] = `
 exports[`InputField InputField renders with a tabIndex value 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField23"
+  htmlFor="stxField45"
+  messageId="stxFieldMessage46"
 >
   <Input
-    id="stxField23"
+    aria-describedby="stxFieldMessage46"
+    id="stxField45"
     selectOnFocus={false}
     tabIndex={-5}
     type="text"
@@ -194,8 +221,10 @@ exports[`InputField InputField renders with basic props 1`] = `
   ariaLive="assertive"
   className="stx-field--with-input html-class"
   htmlFor="test-id"
+  messageId="stxFieldMessage2"
 >
   <Input
+    aria-describedby="stxFieldMessage2"
     data-additional-prop="additional-prop-test"
     id="test-id"
     name="name"
@@ -215,10 +244,12 @@ exports[`InputField InputField renders with basic props 1`] = `
 exports[`InputField InputField renders with size small 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField16"
+  htmlFor="stxField31"
+  messageId="stxFieldMessage32"
 >
   <Input
-    id="stxField16"
+    aria-describedby="stxFieldMessage32"
+    id="stxField31"
     selectOnFocus={false}
     size="small"
     type="text"
@@ -229,10 +260,12 @@ exports[`InputField InputField renders with size small 1`] = `
 exports[`InputField InputField renders with type date 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField6"
+  htmlFor="stxField11"
+  messageId="stxFieldMessage12"
 >
   <Input
-    id="stxField6"
+    aria-describedby="stxFieldMessage12"
+    id="stxField11"
     selectOnFocus={false}
     type="date"
   />
@@ -242,10 +275,12 @@ exports[`InputField InputField renders with type date 1`] = `
 exports[`InputField InputField renders with type datetime-local 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField7"
+  htmlFor="stxField13"
+  messageId="stxFieldMessage14"
 >
   <Input
-    id="stxField7"
+    aria-describedby="stxFieldMessage14"
+    id="stxField13"
     selectOnFocus={false}
     type="datetime-local"
   />
@@ -255,10 +290,12 @@ exports[`InputField InputField renders with type datetime-local 1`] = `
 exports[`InputField InputField renders with type email 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField12"
+  htmlFor="stxField23"
+  messageId="stxFieldMessage24"
 >
   <Input
-    id="stxField12"
+    aria-describedby="stxFieldMessage24"
+    id="stxField23"
     selectOnFocus={false}
     type="email"
   />
@@ -268,10 +305,12 @@ exports[`InputField InputField renders with type email 1`] = `
 exports[`InputField InputField renders with type file 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField15"
+  htmlFor="stxField29"
+  messageId="stxFieldMessage30"
 >
   <Input
-    id="stxField15"
+    aria-describedby="stxFieldMessage30"
+    id="stxField29"
     selectOnFocus={false}
     type="file"
   />
@@ -281,10 +320,12 @@ exports[`InputField InputField renders with type file 1`] = `
 exports[`InputField InputField renders with type number 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField10"
+  htmlFor="stxField19"
+  messageId="stxFieldMessage20"
 >
   <Input
-    id="stxField10"
+    aria-describedby="stxFieldMessage20"
+    id="stxField19"
     selectOnFocus={false}
     type="number"
   />
@@ -294,10 +335,12 @@ exports[`InputField InputField renders with type number 1`] = `
 exports[`InputField InputField renders with type password 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField14"
+  htmlFor="stxField27"
+  messageId="stxFieldMessage28"
 >
   <Input
-    id="stxField14"
+    aria-describedby="stxFieldMessage28"
+    id="stxField27"
     selectOnFocus={false}
     type="password"
   />
@@ -307,10 +350,12 @@ exports[`InputField InputField renders with type password 1`] = `
 exports[`InputField InputField renders with type search 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField9"
+  htmlFor="stxField17"
+  messageId="stxFieldMessage18"
 >
   <Input
-    id="stxField9"
+    aria-describedby="stxFieldMessage18"
+    id="stxField17"
     selectOnFocus={false}
     type="search"
   />
@@ -320,10 +365,12 @@ exports[`InputField InputField renders with type search 1`] = `
 exports[`InputField InputField renders with type tel 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField11"
+  htmlFor="stxField21"
+  messageId="stxFieldMessage22"
 >
   <Input
-    id="stxField11"
+    aria-describedby="stxFieldMessage22"
+    id="stxField21"
     selectOnFocus={false}
     type="tel"
   />
@@ -333,10 +380,12 @@ exports[`InputField InputField renders with type tel 1`] = `
 exports[`InputField InputField renders with type text 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField5"
+  htmlFor="stxField9"
+  messageId="stxFieldMessage10"
 >
   <Input
-    id="stxField5"
+    aria-describedby="stxFieldMessage10"
+    id="stxField9"
     selectOnFocus={false}
     type="text"
   />
@@ -346,10 +395,12 @@ exports[`InputField InputField renders with type text 1`] = `
 exports[`InputField InputField renders with type time 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField8"
+  htmlFor="stxField15"
+  messageId="stxFieldMessage16"
 >
   <Input
-    id="stxField8"
+    aria-describedby="stxFieldMessage16"
+    id="stxField15"
     selectOnFocus={false}
     type="time"
   />
@@ -359,10 +410,12 @@ exports[`InputField InputField renders with type time 1`] = `
 exports[`InputField InputField renders with type url 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField13"
+  htmlFor="stxField25"
+  messageId="stxFieldMessage26"
 >
   <Input
-    id="stxField13"
+    aria-describedby="stxFieldMessage26"
+    id="stxField25"
     selectOnFocus={false}
     type="url"
   />
@@ -372,10 +425,12 @@ exports[`InputField InputField renders with type url 1`] = `
 exports[`InputField InputField renders without any props 1`] = `
 <Field
   className="stx-field--with-input"
-  htmlFor="stxField2"
+  htmlFor="stxField3"
+  messageId="stxFieldMessage4"
 >
   <Input
-    id="stxField2"
+    aria-describedby="stxFieldMessage4"
+    id="stxField3"
     selectOnFocus={false}
     type="text"
   />

--- a/src/components/pill/Pill.test.js
+++ b/src/components/pill/Pill.test.js
@@ -1,3 +1,4 @@
+/* global describe, test, expect, jest */
 import React from 'react';
 import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
@@ -6,8 +7,8 @@ import Pill from './Pill';
 describe('Pill', () => {
   test('Pill renders with basic props', () => {
     const component = shallow(<Pill
-      className="class-name"
-      label="label"
+      className='class-name'
+      label='label'
     />);
 
     expect(toJson(component)).toMatchSnapshot();
@@ -15,7 +16,7 @@ describe('Pill', () => {
 
   test('Pill renders with a11y props', () => {
     const component = shallow(<Pill
-      aria-label="aria-label"
+      aria-label='aria-label'
     />);
 
     const span = component.find('span.stx-pill');
@@ -39,7 +40,7 @@ describe('Pill', () => {
 
   test('Pill renders with alert status', () => {
     const component = shallow(<Pill
-      status="alert"
+      status='alert'
     />);
 
     const span = component.find('span.stx-pill--with-alert');
@@ -48,7 +49,7 @@ describe('Pill', () => {
 
   test('Pill renders with warning status', () => {
     const component = shallow(<Pill
-      status="warning"
+      status='warning'
     />);
 
     const span = component.find('span.stx-pill--with-warning');
@@ -57,7 +58,7 @@ describe('Pill', () => {
 
   test('Pill renders with success status', () => {
     const component = shallow(<Pill
-      status="success"
+      status='success'
     />);
 
     const span = component.find('span.stx-pill--with-success');
@@ -66,7 +67,7 @@ describe('Pill', () => {
 
   test('Pill renders with info status', () => {
     const component = shallow(<Pill
-      status="info"
+      status='info'
     />);
 
     const span = component.find('span.stx-pill--with-info');

--- a/src/components/radiofield/RadioField.js
+++ b/src/components/radiofield/RadioField.js
@@ -12,14 +12,17 @@ class RadioField extends Component {
   constructor(props) {
     super(props);
     this.forId = `stxField${generateUniqueId()}`;
+    this.messageId = `stxFieldMessage${generateUniqueId()}`;
   }
 
   render() {
-    const { className, disabled, helpText, id, label, messageType, messageText, value, ...otherProps } = this.props;
+    const { className, disabled, helpText, id, label, messageType, messageText, messageId, value, ...otherProps } = this.props;
     const classNames = cn([
       'stx-field--with-radio-field',
       className,
     ]);
+
+    const hasValidationError = messageType === 'alert' || messageType === 'error';
 
     return (
       <Field
@@ -36,6 +39,8 @@ class RadioField extends Component {
             className='stx-radio-field__radio'
             disabled={disabled}
             value={value}
+            aria-invalid={hasValidationError ? 'true' : undefined}
+            aria-describedby={messageId || this.messageId}
           />
 
           <label htmlFor={id || this.forId} className='stx-radio-field__label'>
@@ -71,6 +76,9 @@ RadioField.propTypes = {
 
   /** The type of message to display */
   messageType: PropTypes.oneOf(['success', 'warning', 'alert', '']),
+
+  /** The ID of the associated message element (automatically generated if not provided) */
+  messageId: PropTypes.oneOf([PropTypes.string, PropTypes.undefined]),
 
   /** The value of the checkbox component */
   value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),

--- a/src/components/radiofield/__snapshots__/RadioField.test.js.snap
+++ b/src/components/radiofield/__snapshots__/RadioField.test.js.snap
@@ -9,13 +9,14 @@ exports[`RadioField RadioField render disabled when disabled is true 1`] = `
     className="stx-radio-field"
   >
     <Radio
+      aria-describedby="stxFieldMessage4"
       className="stx-radio-field__radio"
       disabled={true}
-      id="stxField2"
+      id="stxField3"
     />
     <label
       className="stx-radio-field__label"
-      htmlFor="stxField2"
+      htmlFor="stxField3"
     />
   </div>
 </Field>
@@ -48,6 +49,8 @@ exports[`RadioField RadioField renders with basic props 1`] = `
         className="stx-radio-field"
       >
         <Radio
+          aria-describedby="stxFieldMessage2"
+          aria-invalid="true"
           checked={true}
           className="stx-radio-field__radio"
           data-additional-prop="additional-prop"
@@ -64,7 +67,9 @@ exports[`RadioField RadioField renders with basic props 1`] = `
           >
             <input
               aria-checked={true}
+              aria-describedby="stxFieldMessage2"
               aria-disabled={true}
+              aria-invalid="true"
               checked={true}
               className="stx-radio__input"
               data-additional-prop="additional-prop"

--- a/src/components/select/Select.js
+++ b/src/components/select/Select.js
@@ -82,7 +82,7 @@ class Select extends Component {
           {children}
 
         </select>
-        <span className='stx-select__icon'>
+        <span className='stx-select__icon' aria-hidden>
           <svg
             className='stx-select-icon__icon'
             viewBox='0 0 24 24'

--- a/src/components/select/__snapshots__/Select.test.js.snap
+++ b/src/components/select/__snapshots__/Select.test.js.snap
@@ -44,6 +44,7 @@ exports[`Select Select renders with basic props 1`] = `
       </option>
     </select>
     <span
+      aria-hidden={true}
       className="stx-select__icon"
     >
       <svg
@@ -119,6 +120,7 @@ exports[`Select Select renders with disabled 1`] = `
       </option>
     </select>
     <span
+      aria-hidden={true}
       className="stx-select__icon"
     >
       <svg
@@ -193,6 +195,7 @@ exports[`Select Select renders with loading 1`] = `
       </option>
     </select>
     <span
+      aria-hidden={true}
       className="stx-select__icon"
     >
       <svg
@@ -266,6 +269,7 @@ exports[`Select Select renders with messageType = alert 1`] = `
       </option>
     </select>
     <span
+      aria-hidden={true}
       className="stx-select__icon"
     >
       <svg
@@ -338,6 +342,7 @@ exports[`Select Select renders with options array 1`] = `
       </option>
     </select>
     <span
+      aria-hidden={true}
       className="stx-select__icon"
     >
       <svg
@@ -413,6 +418,7 @@ exports[`Select Select renders with readOnly 1`] = `
       </option>
     </select>
     <span
+      aria-hidden={true}
       className="stx-select__icon"
     >
       <svg

--- a/src/components/selectfield/SelectField.js
+++ b/src/components/selectfield/SelectField.js
@@ -12,14 +12,17 @@ class SelectField extends Component {
   constructor(props) {
     super(props);
     this.forId = `stxField${generateUniqueId()}`;
+    this.messageId = `stxFieldMessage${generateUniqueId()}`;
   }
 
   render() {
-    const { id, label, className, disabled, readOnly, messageType, messageText, helpText, ariaLive, ...otherProps } = this.props;
+    const { id, label, className, disabled, readOnly, messageType, messageText, messageId, helpText, ariaLive, ...otherProps } = this.props;
     const classNames = cn([
       'stx-field--with-select',
       className,
     ]);
+
+    const hasValidationError = messageType === 'alert' || messageType === 'error';
 
     return (
       <Field
@@ -29,6 +32,7 @@ class SelectField extends Component {
         className={classNames}
         messageType={messageType}
         messageText={messageText}
+        messageId={messageId || this.messageId}
         disabled={disabled}
         readOnly={readOnly}
         ariaLive={ariaLive}
@@ -39,6 +43,8 @@ class SelectField extends Component {
           messageType={messageType}
           disabled={disabled}
           readOnly={readOnly}
+          aria-invalid={hasValidationError ? 'true' : undefined}
+          aria-describedby={messageId || this.messageId}
         />
       </Field>
     );
@@ -67,6 +73,9 @@ SelectField.propTypes = {
 
   /** The type of message to display */
   messageType: PropTypes.oneOf(['alert', 'warning', 'success', '']),
+
+  /** The ID of the associated message element (automatically generated if not provided) */
+  messageId: PropTypes.oneOf([PropTypes.string, PropTypes.undefined]),
 
   /** The aria-live attribute value that will be set on the message if one is given */
   ariaLive: PropTypes.oneOf(['assertive', 'polite']),

--- a/src/components/selectfield/__snapshots__/SelectField.test.js.snap
+++ b/src/components/selectfield/__snapshots__/SelectField.test.js.snap
@@ -15,11 +15,13 @@ exports[`SelectField SelectField renders with basic props 1`] = `
     ariaLive="assertive"
     className="stx-field--with-select the-class"
     htmlFor="stxField1"
+    messageId="stxFieldMessage2"
   >
     <div
       className="stx-field stx-field--with-select the-class"
     >
       <Select
+        aria-describedby="stxFieldMessage2"
         id="stxField1"
         onBlur={[Function]}
         onChange={[Function]}
@@ -32,6 +34,7 @@ exports[`SelectField SelectField renders with basic props 1`] = `
           className="stx-select stx-select--with-placeholder"
         >
           <select
+            aria-describedby="stxFieldMessage2"
             className="stx-select__select-element"
             id="stxField1"
             onBlur={[Function]}
@@ -63,6 +66,7 @@ exports[`SelectField SelectField renders with basic props 1`] = `
             </option>
           </select>
           <span
+            aria-hidden={true}
             className="stx-select__icon"
           >
             <svg


### PR DESCRIPTION
### Overview
This PR does 3 things:

1. It improves the screen reader accessibility of the `InputField`, `CheckboxField`, `SelectField`, and `RadioField` components (see detailed description below).
1. Add adds `aria-hidden` to the dropdown icons.
1. It fixes linting erros in Pill.test.js.

#### *Field Component Accessibility Explanation
[An earlier commit](https://github.com/bold-commerce/stacks-ui/commit/8e2c44908a6ee2435fb3e43d86f71a8d97bc8e4e) added `aria-live` to the error messages in these components. This change made it so that, whenever the error messages in these components changed, screen readers would announce them. However, these errors were only announced when the error messages first changed; when users subsequently tried to tab through a form to fix the errors, the actual error messages were not announced.

This PR fixes that by having each of the form controls be `aria-describedby` the associated error message.

In addition, I've also added `aria-invalid` to each of these controls, which will be read out by some screen readers (e.g. "Email address, input field" becomes something like "Email address, input field, invalid,").

#### Adding `aria-hidden` to dropdown icons
The select components contain a small arrow icon. This is great for sighted users. However, when screen reader users navigate through the interface, the screen reader also announces the icon. Screen reader users already receive an announcement about the actual form control, so this adds clutter to their experience without being useful. Adding `aria-hidden` removes this from the screen reader navigation without affecting the sighted user experience.